### PR TITLE
Added go.mod and fixed shadowing

### DIFF
--- a/convertion.go
+++ b/convertion.go
@@ -79,7 +79,7 @@ func jalCal(jy int) (int, int, int, error) {
 	// Find the limiting years for the Jalaali year jy.
 	for i := 1; i < bl; i++ {
 		jm := breaks[i]
-		jump := jm - jp
+		jump = jm - jp
 		if jy < jm {
 			break
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jalaali/go-jalaali
+
+go 1.13


### PR DESCRIPTION
Hello
There was a variable shadowing with `jump` which I think it wasn't intended like this because it is not edited outside the loop but yet it is used.
I also added go modules
