### PR TITLE
fix : validate the Jalaali month before performing the conversion

### DIFF
--- a/convertion.go
+++ b/convertion.go
@@ -20,9 +20,9 @@ func ToJalaali(gregorianYear int, gregorianMonth time.Month, gregorianDay int) (
 // ToGregorian converts Jalaali to Gregorian date. Error is not nil if Jalaali
 // year passed to function is not valid.
 func ToGregorian(jalaaliYear int, jalaaliMonth Month, jalaaliDay int) (int, time.Month, int, error) {
-	// validate the jalaali month
-	if jalaaliMonth < 1 || jalaaliMonth > 12 {
-		return 0, 0, 0, fmt.Errorf("invalid jalaali month: %d", jalaaliMonth)
+	// validate the jalaali date using the utility function
+	if !IsValidDate(jalaaliYear, int(jalaaliMonth), jalaaliDay) {
+		return 0, 0, 0, fmt.Errorf("invalid jalaali date: year=%d, month=%d, day=%d", jalaaliYear, jalaaliMonth, jalaaliDay)
 	}
 	jdn, err := j2d(jalaaliYear, int(jalaaliMonth), jalaaliDay)
 	if err != nil {

--- a/convertion.go
+++ b/convertion.go
@@ -1,6 +1,9 @@
 package jalaali
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 var (
 	breaks = [...]int{-61, 9, 38, 199, 426, 686, 756, 818, 1111, 1181, 1210,
@@ -17,6 +20,10 @@ func ToJalaali(gregorianYear int, gregorianMonth time.Month, gregorianDay int) (
 // ToGregorian converts Jalaali to Gregorian date. Error is not nil if Jalaali
 // year passed to function is not valid.
 func ToGregorian(jalaaliYear int, jalaaliMonth Month, jalaaliDay int) (int, time.Month, int, error) {
+	// validate the jalaali month
+	if jalaaliMonth < 1 || jalaaliMonth > 12 {
+		return 0, 0, 0, fmt.Errorf("invalid jalaali month: %d", jalaaliMonth)
+	}
 	jdn, err := j2d(jalaaliYear, int(jalaaliMonth), jalaaliDay)
 	if err != nil {
 		return 0, 0, 0, err


### PR DESCRIPTION
The issue stems from the fact that the ToGregorian function doesn't validate the Jalaali month before performing the conversion. It assumes the month is valid, leading to incorrect behavior when an invalid month like 15 is passed.